### PR TITLE
Added additional security layer in walletd in RPC mode

### DIFF
--- a/src/JsonRpcServer/JsonRpcServer.cpp
+++ b/src/JsonRpcServer/JsonRpcServer.cpp
@@ -45,8 +45,8 @@ JsonRpcServer::JsonRpcServer(System::Dispatcher& sys, System::Event& stopEvent, 
 {
 }
 
-void JsonRpcServer::start(const std::string& bindAddress, uint16_t bindPort, const std::string& m_rpcUser, const std::string& m_rpcPassword) {
-  HttpServer::start(bindAddress, bindPort, m_rpcUser, m_rpcPassword);
+void JsonRpcServer::start(const std::string& bindAddress, uint16_t bindPort) {
+  HttpServer::start(bindAddress, bindPort);
   stopEvent.wait();
   HttpServer::stop();
 }

--- a/src/JsonRpcServer/JsonRpcServer.cpp
+++ b/src/JsonRpcServer/JsonRpcServer.cpp
@@ -45,8 +45,8 @@ JsonRpcServer::JsonRpcServer(System::Dispatcher& sys, System::Event& stopEvent, 
 {
 }
 
-void JsonRpcServer::start(const std::string& bindAddress, uint16_t bindPort) {
-  HttpServer::start(bindAddress, bindPort);
+void JsonRpcServer::start(const std::string& bindAddress, uint16_t bindPort, const std::string& m_rpcUser, const std::string& m_rpcPassword) {
+  HttpServer::start(bindAddress, bindPort, m_rpcUser, m_rpcPassword);
   stopEvent.wait();
   HttpServer::stop();
 }

--- a/src/JsonRpcServer/JsonRpcServer.h
+++ b/src/JsonRpcServer/JsonRpcServer.h
@@ -46,7 +46,7 @@ public:
   JsonRpcServer(System::Dispatcher& sys, System::Event& stopEvent, Logging::ILogger& loggerGroup);
   JsonRpcServer(const JsonRpcServer&) = delete;
 
-  void start(const std::string& bindAddress, uint16_t bindPort);
+  void start(const std::string& bindAddress, uint16_t bindPort, const std::string& m_rpcUser, const std::string& m_rpcPassword);
 
 protected:
   static void makeErrorResponse(const std::error_code& ec, Common::JsonValue& resp);

--- a/src/JsonRpcServer/JsonRpcServer.h
+++ b/src/JsonRpcServer/JsonRpcServer.h
@@ -46,7 +46,7 @@ public:
   JsonRpcServer(System::Dispatcher& sys, System::Event& stopEvent, Logging::ILogger& loggerGroup);
   JsonRpcServer(const JsonRpcServer&) = delete;
 
-  void start(const std::string& bindAddress, uint16_t bindPort, const std::string& m_rpcUser, const std::string& m_rpcPassword);
+  void start(const std::string& bindAddress, uint16_t bindPort);
 
 protected:
   static void makeErrorResponse(const std::error_code& ec, Common::JsonValue& resp);

--- a/src/PaymentGateService/PaymentGateService.cpp
+++ b/src/PaymentGateService/PaymentGateService.cpp
@@ -255,7 +255,7 @@ void PaymentGateService::runWalletService(const CryptoNote::Currency& currency, 
     }
   } else {
     PaymentService::PaymentServiceJsonRpcServer rpcServer(*dispatcher, *stopEvent, *service, logger);
-	rpcServer.start(config.gateConfiguration.bindAddress, config.gateConfiguration.bindPort, config.gateConfiguration.m_rpcUser, config.gateConfiguration.m_rpcPassword);
+    rpcServer.start(config.gateConfiguration.bindAddress, config.gateConfiguration.bindPort);
 
     Logging::LoggerRef(logger, "PaymentGateService")(Logging::INFO, Logging::BRIGHT_WHITE) << "JSON-RPC server stopped, stopping wallet service...";
 

--- a/src/PaymentGateService/PaymentGateService.cpp
+++ b/src/PaymentGateService/PaymentGateService.cpp
@@ -255,7 +255,7 @@ void PaymentGateService::runWalletService(const CryptoNote::Currency& currency, 
     }
   } else {
     PaymentService::PaymentServiceJsonRpcServer rpcServer(*dispatcher, *stopEvent, *service, logger);
-    rpcServer.start(config.gateConfiguration.bindAddress, config.gateConfiguration.bindPort);
+	rpcServer.start(config.gateConfiguration.bindAddress, config.gateConfiguration.bindPort, config.gateConfiguration.m_rpcUser, config.gateConfiguration.m_rpcPassword);
 
     Logging::LoggerRef(logger, "PaymentGateService")(Logging::INFO, Logging::BRIGHT_WHITE) << "JSON-RPC server stopped, stopping wallet service...";
 

--- a/src/PaymentGateService/PaymentServiceConfiguration.cpp
+++ b/src/PaymentGateService/PaymentServiceConfiguration.cpp
@@ -38,16 +38,12 @@ Configuration::Configuration() {
   logLevel = Logging::INFO;
   bindAddress = "";
   bindPort = 0;
-  m_rpcUser = "";
-  m_rpcPassword = "";
 }
 
 void Configuration::initOptions(boost::program_options::options_description& desc) {
   desc.add_options()
       ("bind-address", po::value<std::string>()->default_value("0.0.0.0"), "payment service bind address")
       ("bind-port", po::value<uint16_t>()->default_value(8070), "payment service bind port")
-	  ("rpc-user", po::value<std::string>(), "Username to use the rpc server. If authorization is not required, leave it empty")
-	  ("rpc-password", po::value<std::string>(), "Password to use the rpc server. If authorization is not required, leave it empty")
       ("container-file,w", po::value<std::string>(), "container file")
       ("container-password,p", po::value<std::string>(), "container password")
       ("generate-container,g", "generate new container file with one wallet and exit")
@@ -105,14 +101,6 @@ void Configuration::init(const boost::program_options::variables_map& options) {
 
   if (options.count("bind-port") != 0 && (!options["bind-port"].defaulted() || bindPort == 0)) {
     bindPort = options["bind-port"].as<uint16_t>();
-  }
-
-  if (options.count("rpc-user") != 0) {
-	  m_rpcUser = options["rpc-user"].as<std::string>();
-  }
-
-  if (options.count("rpc-password") != 0) {
-	  m_rpcPassword = options["rpc-password"].as<std::string>();
   }
 
   if (options.count("container-file") != 0) {

--- a/src/PaymentGateService/PaymentServiceConfiguration.cpp
+++ b/src/PaymentGateService/PaymentServiceConfiguration.cpp
@@ -38,12 +38,16 @@ Configuration::Configuration() {
   logLevel = Logging::INFO;
   bindAddress = "";
   bindPort = 0;
+  m_rpcUser = "";
+  m_rpcPassword = "";
 }
 
 void Configuration::initOptions(boost::program_options::options_description& desc) {
   desc.add_options()
       ("bind-address", po::value<std::string>()->default_value("0.0.0.0"), "payment service bind address")
       ("bind-port", po::value<uint16_t>()->default_value(8070), "payment service bind port")
+	  ("rpc-user", po::value<std::string>(), "Username to use the rpc server. If authorization is not required, leave it empty")
+	  ("rpc-password", po::value<std::string>(), "Password to use the rpc server. If authorization is not required, leave it empty")
       ("container-file,w", po::value<std::string>(), "container file")
       ("container-password,p", po::value<std::string>(), "container password")
       ("generate-container,g", "generate new container file with one wallet and exit")
@@ -101,6 +105,14 @@ void Configuration::init(const boost::program_options::variables_map& options) {
 
   if (options.count("bind-port") != 0 && (!options["bind-port"].defaulted() || bindPort == 0)) {
     bindPort = options["bind-port"].as<uint16_t>();
+  }
+
+  if (options.count("rpc-user") != 0) {
+	  m_rpcUser = options["rpc-user"].as<std::string>();
+  }
+
+  if (options.count("rpc-password") != 0) {
+	  m_rpcPassword = options["rpc-password"].as<std::string>();
   }
 
   if (options.count("container-file") != 0) {

--- a/src/PaymentGateService/PaymentServiceConfiguration.h
+++ b/src/PaymentGateService/PaymentServiceConfiguration.h
@@ -38,8 +38,6 @@ struct Configuration {
 
   std::string bindAddress;
   uint16_t bindPort;
-  std::string m_rpcUser;
-  std::string m_rpcPassword;
 
   std::string containerFile;
   std::string containerPassword;

--- a/src/PaymentGateService/PaymentServiceConfiguration.h
+++ b/src/PaymentGateService/PaymentServiceConfiguration.h
@@ -38,6 +38,8 @@ struct Configuration {
 
   std::string bindAddress;
   uint16_t bindPort;
+  std::string m_rpcUser;
+  std::string m_rpcPassword;
 
   std::string containerFile;
   std::string containerPassword;


### PR DESCRIPTION
Enables the use of the --rpc-user and --rpc-password flags to request authentication for clients requesting data on walletd rpc_json port
![36337576-a95d8dd6-136f-11e8-8d2f-03667f1443c6](https://user-images.githubusercontent.com/7688208/36337606-59076338-1370-11e8-8505-3eaab7486aea.png)
![36337585-e38b559c-136f-11e8-923d-1392826c83ef](https://user-images.githubusercontent.com/7688208/36337607-592fe498-1370-11e8-9e2c-2d2e3759aa17.png)
